### PR TITLE
feat: support nsfw for news channels

### DIFF
--- a/discord/resource_discord_channel.go
+++ b/discord/resource_discord_channel.go
@@ -238,13 +238,11 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, m interfac
 	d.Set("position", channel.Position)
 
 	switch channelType {
-	case "text":
+	case "text", "news":
 		{
 			d.Set("topic", channel.Topic)
 			d.Set("nsfw", channel.NSFW)
 		}
-	case "news":
-		d.Set("topic", channel.Topic)
 	case "voice":
 		{
 			d.Set("bitrate", channel.Bitrate)

--- a/discord/resource_discord_news_channel.go
+++ b/discord/resource_discord_news_channel.go
@@ -20,6 +20,12 @@ func resourceDiscordNewsChannel() *schema.Resource {
 				Optional:    true,
 				Description: "Topic of the channel.",
 			},
+			"nsfw": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether the channel is NSFW.",
+			},
 		}),
 	}
 }

--- a/discord/resource_discord_news_channel_test.go
+++ b/discord/resource_discord_news_channel_test.go
@@ -27,6 +27,7 @@ func TestAccResourceDiscordNewsChannel(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "position", "1"),
 					resource.TestCheckResourceAttrSet(name, "channel_id"),
 					resource.TestCheckResourceAttr(name, "topic", "Testing news channel"),
+					resource.TestCheckResourceAttr(name, "nsfw", "false"),
 					resource.TestCheckResourceAttr(name, "sync_perms_with_category", "false"),
 				),
 			},
@@ -41,6 +42,7 @@ func testAccResourceDiscordNewsChannel(serverID string) string {
       name = "terraform-news-channel"
       position = 1
       topic = "Testing news channel"
+      nsfw = false
       sync_perms_with_category = false
 	}`, serverID)
 }


### PR DESCRIPTION
Adds support for nsfw on news channels

This is also a fix for a bug as the `resourceChannelUpdate` function in the provider handled `case "text", "news":` together and unconditionally calls `d.Get("nsfw").(bool)`. But the `discord_news_channel` schema didn't include an `nsfw` field, so `d.Get("nsfw")` returned nil, and the `.(bool)` type assertion panicked. Adding support for `nsfw` resolves this.